### PR TITLE
feat(init): initialize Electron project with single BrowserWindow an basic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# Dissonance UI (Electron shell)
+
+This folder contains the Electron shell for the Dissonance desktop app. For now it is a minimal JavaScript-only Electron project.
+
+## What this initial issue includes
+
+- Electron initialized with a single BrowserWindow
+- JavaScript-only (no TypeScript, no bundler)
+- Single-instance lock to avoid double windows
+
+## Install and run
+
+```bash
+cd ui
+npm install
+npm run dev   # or: npm start
+```
+
+This will launch the Electron window that loads `index.html`.
+
+As we implement more issues, the UI from `.testing/` will gradually be ported into this folder (IPC, preload, audio player, etc.).
+
+---
+
 # Dissonance UI (Electron Desktop App)
 
 This repository contains the downloadable desktop app for the Dissonance project, built with Electron and web technologies.

--- a/package.json
+++ b/package.json
@@ -1,19 +1,18 @@
 {
   "name": "dissonance-ui",
   "version": "0.1.0",
+  "private": true,
+  "description": "Dissonance UI Electron shell (JavaScript only)",
   "main": "main.js",
-  "description": "Dissonance: Protecting your audio from AI exploitation—Electron desktop app.",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder",
+    "dev": "electron .",
     "test": "echo \"No tests yet\""
   },
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "electron": "^28.0.0",
-    "electron-builder": "^24.6.0"
+    "electron": "^28.0.0"
   },
   "dependencies": {}
 }
-


### PR DESCRIPTION
This pull request sets up the initial Electron shell for the Dissonance desktop app. It introduces a minimal JavaScript-only Electron project with a single BrowserWindow, adds a single-instance lock to prevent multiple windows, and updates project metadata and documentation. The changes lay the groundwork for future UI development.

**Electron app initialization and main process logic:**

* Added a single BrowserWindow with improved security settings (disabled `nodeIntegration`, enabled `contextIsolation`), set initial window size, and ensured the window is shown only when ready. Also added error handling for loading `index.html`. (`main.js`)
* Implemented a single-instance lock to prevent multiple app windows and handle focusing/restoring the existing window if a second instance is attempted. (`main.js`)

**Project setup and metadata:**

* Updated `package.json` to mark the project as private, added a description, removed the unused build script, and added a `dev` script alias for starting the app. (`package.json`)

**Documentation:**

* Added a new section to `README.md` describing the Electron shell, its initial features, and instructions for installation and running the app. (`README.md`)