### PR TITLE
implement audio playback before

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ npm run dev   # or: npm start
 ```
 
 This will launch the Electron window that loads `index.html`.
-
 As we implement more issues, the UI from `.testing/` will gradually be ported into this folder (IPC, preload, audio player, etc.).
 
 ---
@@ -88,9 +87,34 @@ The app is structured to be easy to extend and keep responsibilities separated:
   - `renderer/infrastructure/` wraps platform/bridge concerns.
   - `renderer/base/` provides shared lifecycle + disposal helpers.
 
+Current main flow views:
+
+- Upload → Analyze / Prepare → Compare → Export
+
 More detail: see `renderer/ARCHITECTURE.md`.
 
 ---
+
+## Audio playback + waveform (Analyze / Prepare)
+
+The Analyze / Prepare step includes an audio preview with waveform visualization using:
+
+- `@arraypress/waveform-player`
+
+How it is integrated (no bundler):
+
+- The player is loaded from `node_modules` via `<link>` + `<script>` tags in `index.html`.
+- The renderer instantiates `window.WaveformPlayer` inside the Analyze view.
+
+Key files:
+
+- `index.html`: loads `waveform-player.css` and `waveform-player.min.js` and defines `#analyzeWaveform`.
+- `renderer/views/AnalyzeView.js`: creates/destroys the player and loads the current audio file.
+- `renderer/controllers/AppController.js`: sets/clears the preview when importing/resetting and pauses playback on navigation.
+
+Notes:
+
+- The app’s Content Security Policy allows local audio loading for preview (`media-src file:` and `connect-src file:`).
 
 ## CI/CD
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,21 @@
     <title>Dissonance UI (IPC demo)</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' file:; media-src 'self' file: data:;"
     />
     <link rel="stylesheet" href="./styles.css" />
+    <link
+      rel="stylesheet"
+      href="./node_modules/@arraypress/waveform-player/dist/waveform-player.css"
+    />
   </head>
   <body>
     <header>
-      <h1>Dissonance UI</h1>
-      <p>Import an audio file, then process and export it via simulated dissonance-core.</p>
+      <h1>Dissonance</h1>
+      <p>
+        Import an audio file, follow the instructions, and well make sure your audio is safe from
+        unethical AI training
+      </p>
     </header>
     <main>
       <section id="view-upload" class="view">
@@ -84,21 +91,7 @@
             <div id="analyzeMetaChannels" class="value">—</div>
           </div>
 
-          <div class="controls">
-            <button id="analyzeNextBtn" class="secondaryBtn" type="button" disabled>
-              Continue
-            </button>
-          </div>
-        </div>
-      </section>
-
-      <section id="view-process" class="view" hidden>
-        <div class="step">
-          <h2 class="stepTitle">Process</h2>
-
-          <div class="fileRow">
-            <div id="processSelectedFile" class="selectedFile">No file selected</div>
-          </div>
+          <div id="analyzeWaveform" aria-label="Audio preview"></div>
 
           <div class="controls">
             <button id="processBtn" class="primaryBtn processBtn" type="button" disabled>
@@ -166,6 +159,7 @@
         </div>
       </section>
     </main>
+    <script src="./node_modules/@arraypress/waveform-player/dist/waveform-player.min.js"></script>
     <script type="module" src="./renderer/index.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@arraypress/waveform-player": "^1.5.2",
         "bindings": "^1.5.0"
       },
       "devDependencies": {
@@ -18,6 +19,19 @@
         "eslint": "^10.0.1",
         "globals": "^17.3.0",
         "prettier": "^3.6.2"
+      }
+    },
+    "node_modules/@arraypress/waveform-player": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.5.2.tgz",
+      "integrity": "sha512-Rv5Jfy4T4mnG4LRzGu+Z2Ka/0y0Ca2B0+L94Sbz+zCan30IdM3aWddIEYnlO3MMNvrutt7EL9ZbPOJw1gNIhEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/arraypress"
       }
     },
     "node_modules/@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@arraypress/waveform-player": "^1.5.2",
     "bindings": "^1.5.0"
   },
   "devDependencies": {

--- a/renderer/ARCHITECTURE.md
+++ b/renderer/ARCHITECTURE.md
@@ -23,7 +23,10 @@ This UI is organized as a small OOP/MVC-ish structure where:
 - `renderer/controllers/`
   - `AppController.js`: application orchestration.
 - `renderer/views/`
-  - `WelcomeView.js`, `MainView.js`: view-specific UI updates and event wiring.
+  - `UploadView.js`: upload step (drop zone).
+  - `AnalyzeView.js`: analyze/prepare step (metadata + waveform preview + process action).
+  - `CompareView.js`: original vs processed summary.
+  - `ExportView.js`: export step.
 - `renderer/components/`
   - `DropZone.js`: reusable drag/drop + click-to-open component.
 - `renderer/services/`
@@ -51,3 +54,11 @@ This UI is organized as a small OOP/MVC-ish structure where:
 3. Orchestrate it in a controller.
 
 Keep `renderer/app/bootstrap.js` as the only place that constructs and wires all dependencies.
+
+## Waveform playback integration
+
+The Analyze / Prepare step uses `@arraypress/waveform-player` for playback + waveform.
+
+- `index.html` loads the library assets from `node_modules` (no bundler) and provides the `#analyzeWaveform` container.
+- `AnalyzeView.js` instantiates `window.WaveformPlayer` and exposes `pauseAudioPreview()` / `clearAudioPreview()`.
+- `AppController.js` pauses the preview when leaving Analyze and clears it when resetting the flow.

--- a/renderer/app/bootstrap.js
+++ b/renderer/app/bootstrap.js
@@ -4,7 +4,6 @@ import { ViewRouter } from '../infrastructure/ViewRouter.js';
 import { AppState } from '../state/AppState.js';
 import { UploadView } from '../views/UploadView.js';
 import { AnalyzeView } from '../views/AnalyzeView.js';
-import { ProcessView } from '../views/ProcessView.js';
 import { CompareView } from '../views/CompareView.js';
 import { ExportView } from '../views/ExportView.js';
 import { AppController } from '../controllers/AppController.js';
@@ -25,7 +24,6 @@ export function bootstrap() {
   const router = new ViewRouter({
     upload: document.getElementById('view-upload'),
     analyze: document.getElementById('view-analyze'),
-    process: document.getElementById('view-process'),
     compare: document.getElementById('view-compare'),
     export: document.getElementById('view-export'),
   });
@@ -46,11 +44,7 @@ export function bootstrap() {
     metaDurationEl: document.getElementById('analyzeMetaDuration'),
     metaSampleRateEl: document.getElementById('analyzeMetaSampleRate'),
     metaChannelsEl: document.getElementById('analyzeMetaChannels'),
-    nextBtn: document.getElementById('analyzeNextBtn'),
-  });
-
-  const processView = new ProcessView({
-    selectedFileEl: document.getElementById('processSelectedFile'),
+    waveformEl: document.getElementById('analyzeWaveform'),
     processBtn: document.getElementById('processBtn'),
   });
 
@@ -78,7 +72,6 @@ export function bootstrap() {
     state,
     uploadView,
     analyzeView,
-    processView,
     compareView,
     exportView,
     wavMetadataService,

--- a/renderer/controllers/AppController.js
+++ b/renderer/controllers/AppController.js
@@ -8,7 +8,6 @@ export class AppController extends BaseController {
     state,
     uploadView,
     analyzeView,
-    processView,
     compareView,
     exportView,
     wavMetadataService,
@@ -20,7 +19,6 @@ export class AppController extends BaseController {
     this.state = state;
     this.uploadView = uploadView;
     this.analyzeView = analyzeView;
-    this.processView = processView;
     this.compareView = compareView;
     this.exportView = exportView;
     this.wavMetadataService = wavMetadataService;
@@ -39,9 +37,6 @@ export class AppController extends BaseController {
 
     this.analyzeView.mount();
     this.track(() => this.analyzeView.unmount());
-
-    this.processView.mount();
-    this.track(() => this.processView.unmount());
 
     this.compareView.mount();
     this.track(() => this.compareView.unmount());
@@ -70,12 +65,7 @@ export class AppController extends BaseController {
       }
     });
 
-    this.analyzeView.onNext(() => {
-      if (!this.state.currentFilePath) return;
-      this._showProcess();
-    });
-
-    this.processView.onProcess(() => this.processCurrentFile());
+    this.analyzeView.onProcess(() => this.processCurrentFile());
 
     this.compareView.onNext(() => {
       if (!this.state.processedFilePath) return;
@@ -115,8 +105,8 @@ export class AppController extends BaseController {
 
     this.analyzeView.setSelectedFile(filePath);
     this.analyzeView.setBasicWavInfo(this._originalBasicInfo);
-    this.analyzeView.setNextEnabled(true);
-    this.processView.setSelectedFile(filePath);
+    this.analyzeView.setAudioPreviewFile(filePath);
+    this.analyzeView.setProcessEnabled(true);
     this.exportView.setSelectedFile(null);
 
     this.logger?.log?.(`${sourceLabel} file: ${filePath}`);
@@ -219,10 +209,9 @@ export class AppController extends BaseController {
   }
 
   _syncButtons() {
-    this.processView.setProcessEnabled(this.state.hasCurrentFile());
+    this.analyzeView.setProcessEnabled(this.state.hasCurrentFile());
     this.exportView.setExportEnabled(this.state.hasProcessedFile());
     this.compareView.setNextEnabled(this.state.hasProcessedFile());
-    this.analyzeView.setNextEnabled(this.state.hasCurrentFile());
   }
 
   _showAnalyze() {
@@ -230,29 +219,27 @@ export class AppController extends BaseController {
     this._syncButtons();
   }
 
-  _showProcess() {
-    this.router.show('process');
-    this._syncButtons();
-  }
-
   _showCompare() {
+    this.analyzeView.pauseAudioPreview();
     this.router.show('compare');
     this._syncButtons();
   }
 
   _showExport() {
+    this.analyzeView.pauseAudioPreview();
     this.exportView.setSelectedFile(this.state.processedFilePath);
     this.router.show('export');
     this._syncButtons();
   }
 
   _resetToUpload() {
+    this.analyzeView.pauseAudioPreview();
     this.state.setCurrentFilePath(null);
     this._originalBasicInfo = null;
     this._processedBasicInfo = null;
     this.analyzeView.setSelectedFile(null);
     this.analyzeView.setBasicWavInfo(null);
-    this.processView.setSelectedFile(null);
+    this.analyzeView.clearAudioPreview();
     this.compareView.setOriginalInfo(null);
     this.compareView.setProcessedInfo(null);
     this.exportView.setSelectedFile(null);

--- a/renderer/views/AnalyzeView.js
+++ b/renderer/views/AnalyzeView.js
@@ -8,7 +8,8 @@ export class AnalyzeView extends BaseView {
     metaDurationEl,
     metaSampleRateEl,
     metaChannelsEl,
-    nextBtn,
+    waveformEl,
+    processBtn,
   }) {
     super();
     this.selectedFileEl = selectedFileEl;
@@ -17,11 +18,91 @@ export class AnalyzeView extends BaseView {
     this.metaDurationEl = metaDurationEl;
     this.metaSampleRateEl = metaSampleRateEl;
     this.metaChannelsEl = metaChannelsEl;
-    this.nextBtn = nextBtn;
+    this.waveformEl = waveformEl;
+    this.processBtn = processBtn;
+
+    this._player = null;
+    this._currentUrl = null;
   }
 
   mount() {
     super.mount();
+    this.track(() => this.clearAudioPreview());
+  }
+
+  setAudioPreviewFile(filePath) {
+    if (!this.waveformEl) return;
+    if (!filePath) {
+      this.clearAudioPreview();
+      return;
+    }
+
+    const url = this._toFileUrl(filePath);
+    if (!url) {
+      this.clearAudioPreview();
+      return;
+    }
+
+    if (this._player && typeof this._player.loadTrack === 'function') {
+      this._currentUrl = url;
+      this._player.loadTrack(url);
+      return;
+    }
+
+    this.clearAudioPreview();
+
+    const WaveformPlayer = window.WaveformPlayer;
+    if (typeof WaveformPlayer !== 'function') {
+      return;
+    }
+
+    this._currentUrl = url;
+    // Ensure the container is empty before attaching the player.
+    this.waveformEl.innerHTML = '';
+
+    this._player = new WaveformPlayer(this.waveformEl, {
+      url,
+      waveformStyle: 'mirror',
+      height: 164,
+      showInfo: false,
+      showTime: false,
+      showBPM: false,
+      showPlaybackSpeed: false,
+      waveformColor: 'rgba(15, 23, 42, 0.25)',
+      progressColor: 'rgba(15, 23, 42, 0.9)',
+      buttonColor: 'rgba(15, 23, 42, 0.9)',
+    });
+  }
+
+  pauseAudioPreview() {
+    try {
+      this._player?.pause?.();
+    } catch (_e) {
+      // ignore
+    }
+  }
+
+  clearAudioPreview() {
+    this._currentUrl = null;
+    try {
+      this._player?.pause?.();
+      this._player?.destroy?.();
+    } catch (_e) {
+      // ignore
+    }
+    this._player = null;
+    if (this.waveformEl) {
+      this.waveformEl.innerHTML = '';
+    }
+  }
+
+  _toFileUrl(filePath) {
+    try {
+      // filePath should be an absolute path like /Users/... on macOS.
+      return new URL(`file://${filePath}`).toString();
+    } catch (_e) {
+      return null;
+    }
   }
 
   setSelectedFile(filePath) {
@@ -57,9 +138,10 @@ export class AnalyzeView extends BaseView {
     }
   }
 
-  setNextEnabled(enabled) {
-    if (!this.nextBtn) return;
-    this.nextBtn.disabled = !enabled;
+  setProcessEnabled(enabled) {
+    if (!this.processBtn) return;
+    this.processBtn.disabled = !enabled;
+    this.processBtn.classList.toggle('enabled', enabled);
   }
 
   onChangeFile(cb) {
@@ -67,8 +149,8 @@ export class AnalyzeView extends BaseView {
     this.listen(this.changeFileBtn, 'click', cb);
   }
 
-  onNext(cb) {
-    if (!this.nextBtn) return;
-    this.listen(this.nextBtn, 'click', cb);
+  onProcess(cb) {
+    if (!this.processBtn) return;
+    this.listen(this.processBtn, 'click', cb);
   }
 }


### PR DESCRIPTION
This pull request removes the separate "Process" step from the UI flow, streamlining the user experience by integrating the audio processing action directly into the "Analyze" step. It also introduces an audio waveform preview using the `@arraypress/waveform-player` library, allowing users to visually preview audio files before processing. Several code and UI updates support these changes.
**Key changes:**

UI/UX Improvements:
* The "Process" step and its associated view and navigation have been removed; users now process audio directly from the "Analyze" 
* The "Analyze" view now displays an interactive audio waveform preview using the `@arraypress/waveform-player` library, with controls to pause and clear the preview as users navigate the app.

Codebase Refactoring:
* All logic and UI elements related to the now-removed "Process" view have been deleted, and related controller/view logic has been updated to reflect the new streamlined flow.
* The `AnalyzeView` class has been expanded to manage the waveform player, including methods for loading, pausing, and clearing the audio preview.
* Button logic in the "Analyze" view has been updated: the "Continue" button is replaced by a "Process" button, and corresponding enable/disable logic and event handlers have been updated.

Dependency and Asset Management:
* The `@arraypress/waveform-player` package has been added to `package.json`, and its CSS and JS assets are now included in `index.html`.

Text and Content Updates:
* The app title and description have been updated to better reflect the application's purpose and workflow.