### PR TITLE
21 implement processed audio output placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,38 +140,54 @@
             <h2 class="m-0 text-center text-base font-semibold text-slate-800">Compare</h2>
 
             <div class="grid grid-cols-1 gap-3 min-[820px]:grid-cols-2">
-              <div
-                class="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
-                aria-label="Original WAV info"
-              >
-                <div class="text-sm text-slate-600">Original</div>
-                <div id="compareOrigFilename" class="text-sm text-slate-900 truncate">—</div>
+              <div class="flex flex-col gap-3">
+                <div
+                  class="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
+                  aria-label="Original WAV info"
+                >
+                  <div class="text-sm text-slate-600">Original</div>
+                  <div id="compareOrigFilename" class="text-sm text-slate-900 truncate">—</div>
 
-                <div class="text-sm text-slate-600">Duration</div>
-                <div id="compareOrigDuration" class="text-sm text-slate-900 truncate">—</div>
+                  <div class="text-sm text-slate-600">Duration</div>
+                  <div id="compareOrigDuration" class="text-sm text-slate-900 truncate">—</div>
 
-                <div class="text-sm text-slate-600">Sample rate</div>
-                <div id="compareOrigSampleRate" class="text-sm text-slate-900 truncate">—</div>
+                  <div class="text-sm text-slate-600">Sample rate</div>
+                  <div id="compareOrigSampleRate" class="text-sm text-slate-900 truncate">—</div>
 
-                <div class="text-sm text-slate-600">Channels</div>
-                <div id="compareOrigChannels" class="text-sm text-slate-900 truncate">—</div>
+                  <div class="text-sm text-slate-600">Channels</div>
+                  <div id="compareOrigChannels" class="text-sm text-slate-900 truncate">—</div>
+                </div>
+
+                <div
+                  id="compareOrigWaveform"
+                  class="min-h-[200px] rounded-lg border border-slate-200 bg-white px-3 py-3"
+                  aria-label="Original audio preview"
+                ></div>
               </div>
 
-              <div
-                class="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
-                aria-label="Processed WAV info"
-              >
-                <div class="text-sm text-slate-600">Processed</div>
-                <div id="compareProcFilename" class="text-sm text-slate-900 truncate">—</div>
+              <div class="flex flex-col gap-3">
+                <div
+                  class="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
+                  aria-label="Processed WAV info"
+                >
+                  <div class="text-sm text-slate-600">Processed</div>
+                  <div id="compareProcFilename" class="text-sm text-slate-900 truncate">—</div>
 
-                <div class="text-sm text-slate-600">Duration</div>
-                <div id="compareProcDuration" class="text-sm text-slate-900 truncate">—</div>
+                  <div class="text-sm text-slate-600">Duration</div>
+                  <div id="compareProcDuration" class="text-sm text-slate-900 truncate">—</div>
 
-                <div class="text-sm text-slate-600">Sample rate</div>
-                <div id="compareProcSampleRate" class="text-sm text-slate-900 truncate">—</div>
+                  <div class="text-sm text-slate-600">Sample rate</div>
+                  <div id="compareProcSampleRate" class="text-sm text-slate-900 truncate">—</div>
 
-                <div class="text-sm text-slate-600">Channels</div>
-                <div id="compareProcChannels" class="text-sm text-slate-900 truncate">—</div>
+                  <div class="text-sm text-slate-600">Channels</div>
+                  <div id="compareProcChannels" class="text-sm text-slate-900 truncate">—</div>
+                </div>
+
+                <div
+                  id="compareProcWaveform"
+                  class="min-h-[200px] rounded-lg border border-slate-200 bg-white px-3 py-3"
+                  aria-label="Processed audio preview"
+                ></div>
               </div>
             </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1166,9 +1166,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/renderer/app/bootstrap.js
+++ b/renderer/app/bootstrap.js
@@ -51,10 +51,12 @@ export function bootstrap() {
     origDurationEl: document.getElementById('compareOrigDuration'),
     origSampleRateEl: document.getElementById('compareOrigSampleRate'),
     origChannelsEl: document.getElementById('compareOrigChannels'),
+    origWaveformEl: document.getElementById('compareOrigWaveform'),
     procFilenameEl: document.getElementById('compareProcFilename'),
     procDurationEl: document.getElementById('compareProcDuration'),
     procSampleRateEl: document.getElementById('compareProcSampleRate'),
     procChannelsEl: document.getElementById('compareProcChannels'),
+    procWaveformEl: document.getElementById('compareProcWaveform'),
     exportBtn: document.getElementById('compareExportBtn'),
   });
 

--- a/renderer/controllers/AppController.js
+++ b/renderer/controllers/AppController.js
@@ -93,6 +93,8 @@ export class AppController extends BaseController {
     this._originalBasicInfo = this.wavMetadataService.toBasicInfo(filePath, null);
     this._processedBasicInfo = null;
 
+    this.compareView.clearAudioPreviews?.();
+
     this.analyzeView.setSelectedFile(filePath);
     this.analyzeView.setBasicWavInfo(this._originalBasicInfo);
     this.analyzeView.setAudioPreviewFile(filePath);
@@ -148,6 +150,10 @@ export class AppController extends BaseController {
 
         this.compareView.setOriginalInfo(this._originalBasicInfo);
         this.compareView.setProcessedInfo(this._processedBasicInfo);
+        this.compareView.setAudioPreviewFiles?.({
+          originalPath: this.state.currentFilePath,
+          processedPath: this.state.processedFilePath,
+        });
         this.compareView.setExportEnabled(true);
 
         this.logger?.setStatus?.('Processed');
@@ -214,6 +220,7 @@ export class AppController extends BaseController {
 
   _resetToUpload() {
     this.analyzeView.pauseAudioPreview();
+    this.compareView.pauseAudioPreviews?.();
     this.state.setCurrentFilePath(null);
     this._originalBasicInfo = null;
     this._processedBasicInfo = null;
@@ -222,6 +229,7 @@ export class AppController extends BaseController {
     this.analyzeView.clearAudioPreview();
     this.compareView.setOriginalInfo(null);
     this.compareView.setProcessedInfo(null);
+    this.compareView.clearAudioPreviews?.();
     this.router.show('upload');
     this._syncButtons();
   }

--- a/renderer/views/CompareView.js
+++ b/renderer/views/CompareView.js
@@ -24,10 +24,12 @@ export class CompareView extends BaseView {
     origDurationEl,
     origSampleRateEl,
     origChannelsEl,
+    origWaveformEl,
     procFilenameEl,
     procDurationEl,
     procSampleRateEl,
     procChannelsEl,
+    procWaveformEl,
     exportBtn,
   }) {
     super();
@@ -35,17 +37,153 @@ export class CompareView extends BaseView {
     this.origDurationEl = origDurationEl;
     this.origSampleRateEl = origSampleRateEl;
     this.origChannelsEl = origChannelsEl;
+    this.origWaveformEl = origWaveformEl;
 
     this.procFilenameEl = procFilenameEl;
     this.procDurationEl = procDurationEl;
     this.procSampleRateEl = procSampleRateEl;
     this.procChannelsEl = procChannelsEl;
+    this.procWaveformEl = procWaveformEl;
 
     this.exportBtn = exportBtn;
+
+    this._origPlayer = null;
+    this._procPlayer = null;
+    this._origUrl = null;
+    this._procUrl = null;
   }
 
   mount() {
     super.mount();
+    this.track(() => this.clearAudioPreviews());
+  }
+
+  setAudioPreviewFiles({ originalPath, processedPath }) {
+    this.setOriginalAudioPreviewFile(originalPath);
+    this.setProcessedAudioPreviewFile(processedPath);
+  }
+
+  setOriginalAudioPreviewFile(filePath) {
+    this._origUrl = null;
+    this._setAudioPreviewInto({
+      filePath,
+      el: this.origWaveformEl,
+      getPlayer: () => this._origPlayer,
+      setPlayer: (p) => {
+        this._origPlayer = p;
+      },
+      setUrl: (url) => {
+        this._origUrl = url;
+      },
+    });
+  }
+
+  setProcessedAudioPreviewFile(filePath) {
+    this._procUrl = null;
+    this._setAudioPreviewInto({
+      filePath,
+      el: this.procWaveformEl,
+      getPlayer: () => this._procPlayer,
+      setPlayer: (p) => {
+        this._procPlayer = p;
+      },
+      setUrl: (url) => {
+        this._procUrl = url;
+      },
+    });
+  }
+
+  pauseAudioPreviews() {
+    try {
+      this._origPlayer?.pause?.();
+    } catch (_e) {}
+    try {
+      this._procPlayer?.pause?.();
+    } catch (_e) {}
+  }
+
+  clearAudioPreviews() {
+    this._origUrl = null;
+    this._procUrl = null;
+
+    try {
+      this._origPlayer?.pause?.();
+      this._origPlayer?.destroy?.();
+    } catch (_e) {}
+    this._origPlayer = null;
+
+    try {
+      this._procPlayer?.pause?.();
+      this._procPlayer?.destroy?.();
+    } catch (_e) {}
+    this._procPlayer = null;
+
+    if (this.origWaveformEl) this.origWaveformEl.innerHTML = '';
+    if (this.procWaveformEl) this.procWaveformEl.innerHTML = '';
+  }
+
+  _setAudioPreviewInto({ filePath, el, getPlayer, setPlayer, setUrl }) {
+    if (!el) return;
+
+    if (!filePath) {
+      if (el) el.innerHTML = '';
+      try {
+        getPlayer()?.pause?.();
+        getPlayer()?.destroy?.();
+      } catch (_e) {}
+      setPlayer(null);
+      setUrl(null);
+      return;
+    }
+
+    const url = this._toFileUrl(filePath);
+    if (!url) {
+      if (el) el.innerHTML = '';
+      try {
+        getPlayer()?.pause?.();
+        getPlayer()?.destroy?.();
+      } catch (_e) {}
+      setPlayer(null);
+      setUrl(null);
+      return;
+    }
+
+    const existing = getPlayer();
+    if (existing && typeof existing.loadTrack === 'function') {
+      setUrl(url);
+      existing.loadTrack(url);
+      return;
+    }
+
+    const WaveformPlayer = window.WaveformPlayer;
+    if (typeof WaveformPlayer !== 'function') return;
+
+    // Ensure container empty before attaching the player.
+    el.innerHTML = '';
+    setUrl(url);
+    setPlayer(
+      new WaveformPlayer(el, {
+        url,
+        waveformStyle: 'mirror',
+        height: 140,
+        showInfo: false,
+        showTime: false,
+        showBPM: false,
+        showPlaybackSpeed: false,
+        waveformColor: 'rgba(15, 23, 42, 0.25)',
+        progressColor: 'rgba(15, 23, 42, 0.9)',
+        buttonColor: 'rgba(15, 23, 42, 0.9)',
+      })
+    );
+  }
+
+  _toFileUrl(filePath) {
+    try {
+      // filePath should be an absolute path like /Users/... on macOS.
+      return new URL(`file://${filePath}`).toString();
+    } catch (_e) {
+      return null;
+    }
   }
 
   setExportEnabled(enabled) {


### PR DESCRIPTION
This pull request adds side-by-side audio waveform previews to the Compare view, allowing users to visually inspect and play both the original and processed audio files. It introduces new UI elements, updates the view and controller logic to manage audio preview players, and ensures proper cleanup and state management when switching files or resetting the view.

**UI Enhancements:**

* Added two new waveform preview containers (`compareOrigWaveform` and `compareProcWaveform`) to the Compare view, displaying visual audio previews for both the original and processed files. [
**View and Player Management:**

* Updated `CompareView` to manage separate audio players and file URLs for the original and processed audio, including methods to set, pause, and clear audio previews. The view now instantiates `WaveformPlayer` for each file and handles lifecycle management to prevent resource leaks.

**Controller Integration:**

* Modified `AppController` to clear, set, and pause audio previews in the Compare view at appropriate times (e.g., when loading a new file, after processing, or when resetting to upload). This ensures the UI and audio players remain in sync with the application state. 

**DOM Wiring:**

* Added references to the new waveform preview elements in the bootstrap logic and passed them into the Compare view for initialization.