### PR TITLE
feat: add settings panel with processing options and integrate into processing workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   </head>
   <body class="min-h-screen bg-white text-slate-900 antialiased">
     <div class="min-h-screen flex flex-col">
-      <header class="px-6 py-4 text-center">
+      <header id="appHeader" class="px-6 py-4 text-center">
         <h1 class="text-2xl font-semibold tracking-tight">Dissonance</h1>
         <p class="mt-2 text-sm text-slate-600 max-w-2xl mx-auto">
           Import an audio file, follow the instructions, and we’ll make sure your audio is safe from
@@ -121,6 +121,53 @@
               class="min-h-[200px] rounded-lg border border-slate-200 bg-white px-3 py-3"
               aria-label="Audio preview"
             ></div>
+
+            <section
+              class="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
+              aria-label="Processing settings"
+            >
+              <h3 class="m-0 text-sm font-semibold text-slate-800">Settings</h3>
+
+              <div class="mt-3 grid grid-cols-1 gap-3 min-[820px]:grid-cols-3">
+                <label class="block">
+                  <div class="text-sm text-slate-600">FFT size</div>
+                  <input
+                    id="settingFftSize"
+                    class="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                    type="number"
+                    inputmode="numeric"
+                    placeholder="2048"
+                    min="1"
+                    step="1"
+                  />
+                </label>
+
+                <label class="block">
+                  <div class="text-sm text-slate-600">Masking strength</div>
+                  <input
+                    id="settingMaskingStrength"
+                    class="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                    type="number"
+                    inputmode="decimal"
+                    placeholder="0.50"
+                    min="0"
+                    max="1"
+                    step="0.05"
+                  />
+                </label>
+
+                <label class="block">
+                  <div class="text-sm text-slate-600">Processing mode</div>
+                  <input
+                    id="settingProcessingMode"
+                    class="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                    type="text"
+                    placeholder="default"
+                    autocomplete="off"
+                  />
+                </label>
+              </div>
+            </section>
 
             <div class="flex justify-center gap-3 items-center flex-wrap pb-2">
               <button

--- a/preload.js
+++ b/preload.js
@@ -13,7 +13,11 @@ contextBridge.exposeInMainWorld('dissonance', {
   },
   getFileStats: (filePath) => ipcRenderer.invoke('file:getStats', filePath),
   inspectFile: (filePath) => ipcRenderer.invoke('core:inspect', filePath),
-  processFile: (filePath) => ipcRenderer.invoke('core:process', filePath),
+  processFile: (filePath, options) =>
+    ipcRenderer.invoke('core:process', {
+      filePath,
+      options: options && typeof options === 'object' ? options : {},
+    }),
   exportFile: (processedPath) => ipcRenderer.invoke('core:export', processedPath),
   cleanupProcessedFile: (processedPath) =>
     ipcRenderer.invoke('core:cleanupProcessed', processedPath),

--- a/renderer/app/bootstrap.js
+++ b/renderer/app/bootstrap.js
@@ -43,6 +43,9 @@ export function bootstrap() {
     metaSampleRateEl: document.getElementById('analyzeMetaSampleRate'),
     metaChannelsEl: document.getElementById('analyzeMetaChannels'),
     waveformEl: document.getElementById('analyzeWaveform'),
+    settingFftSizeEl: document.getElementById('settingFftSize'),
+    settingMaskingStrengthEl: document.getElementById('settingMaskingStrength'),
+    settingProcessingModeEl: document.getElementById('settingProcessingMode'),
     processBtn: document.getElementById('processBtn'),
   });
 
@@ -68,6 +71,7 @@ export function bootstrap() {
     uploadView,
     analyzeView,
     compareView,
+    headerEl: document.getElementById('appHeader'),
     wavMetadataService,
   });
 

--- a/renderer/controllers/AppController.js
+++ b/renderer/controllers/AppController.js
@@ -9,6 +9,7 @@ export class AppController extends BaseController {
     uploadView,
     analyzeView,
     compareView,
+    headerEl,
     wavMetadataService,
   }) {
     super();
@@ -19,6 +20,7 @@ export class AppController extends BaseController {
     this.uploadView = uploadView;
     this.analyzeView = analyzeView;
     this.compareView = compareView;
+    this.headerEl = headerEl;
     this.wavMetadataService = wavMetadataService;
 
     this._originalBasicInfo = null;
@@ -40,6 +42,7 @@ export class AppController extends BaseController {
     this.track(() => this.compareView.unmount());
 
     this.router.show('upload');
+    this._setHeaderVisible(true);
 
     this.uploadView.onFileImported((filePath, sourceLabel) => {
       this.importFile(filePath, sourceLabel);
@@ -139,7 +142,11 @@ export class AppController extends BaseController {
       this.logger?.setStatus?.('Processing...');
       this.logger?.log?.('Sending processing request to dissonance-core (simulated)');
 
-      const resp = await this.api.processFile(this.state.currentFilePath);
+      const options = this.analyzeView?.getProcessingOptions
+        ? this.analyzeView.getProcessingOptions()
+        : {};
+
+      const resp = await this.api.processFile(this.state.currentFilePath, options);
       if (resp && resp.ok && resp.processedPath) {
         this.state.setProcessedFilePath(resp.processedPath);
 
@@ -209,12 +216,14 @@ export class AppController extends BaseController {
 
   _showAnalyze() {
     this.router.show('analyze');
+    this._setHeaderVisible(false);
     this._syncButtons();
   }
 
   _showCompare() {
     this.analyzeView.pauseAudioPreview();
     this.router.show('compare');
+    this._setHeaderVisible(false);
     this._syncButtons();
   }
 
@@ -231,7 +240,13 @@ export class AppController extends BaseController {
     this.compareView.setProcessedInfo(null);
     this.compareView.clearAudioPreviews?.();
     this.router.show('upload');
+    this._setHeaderVisible(true);
     this._syncButtons();
+  }
+
+  _setHeaderVisible(visible) {
+    if (!this.headerEl) return;
+    this.headerEl.hidden = !visible;
   }
 
   _onGlobalDragOver(e) {

--- a/renderer/domain/ProcessingSettings.js
+++ b/renderer/domain/ProcessingSettings.js
@@ -1,0 +1,42 @@
+export const DEFAULT_PROCESSING_SETTINGS = Object.freeze({
+  fftSize: 2048,
+  maskingStrength: 0.5,
+  processingMode: 'default',
+});
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return null;
+  return n;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function readProcessingSettings({
+  fftSizeValue,
+  maskingStrengthValue,
+  processingModeValue,
+} = {}) {
+  const fftSizeNum = toNumberOrNull(fftSizeValue);
+  const fftSize = Number.isInteger(fftSizeNum) && fftSizeNum >= 1 ? fftSizeNum : null;
+
+  const maskingNum = toNumberOrNull(maskingStrengthValue);
+  const maskingStrength = maskingNum !== null ? clamp(maskingNum, 0, 1) : null;
+
+  const processingModeRaw =
+    processingModeValue === null || processingModeValue === undefined
+      ? ''
+      : String(processingModeValue);
+  const processingMode = processingModeRaw.trim() || null;
+
+  return {
+    fftSize: fftSize ?? DEFAULT_PROCESSING_SETTINGS.fftSize,
+    maskingStrength: maskingStrength ?? DEFAULT_PROCESSING_SETTINGS.maskingStrength,
+    processingMode: processingMode ?? DEFAULT_PROCESSING_SETTINGS.processingMode,
+  };
+}

--- a/renderer/infrastructure/DissonanceApi.js
+++ b/renderer/infrastructure/DissonanceApi.js
@@ -21,8 +21,8 @@ export class DissonanceApi extends BaseApi {
     return this._call('cleanupProcessedFile', processedPath);
   }
 
-  async processFile(filePath) {
-    return this._call('processFile', filePath);
+  async processFile(filePath, options) {
+    return this._call('processFile', filePath, options);
   }
 
   async exportFile(processedPath) {

--- a/renderer/views/AnalyzeView.js
+++ b/renderer/views/AnalyzeView.js
@@ -1,4 +1,5 @@
 import { BaseView } from '../base/BaseView.js';
+import { readProcessingSettings } from '../domain/ProcessingSettings.js';
 
 export class AnalyzeView extends BaseView {
   constructor({
@@ -9,6 +10,9 @@ export class AnalyzeView extends BaseView {
     metaSampleRateEl,
     metaChannelsEl,
     waveformEl,
+    settingFftSizeEl,
+    settingMaskingStrengthEl,
+    settingProcessingModeEl,
     processBtn,
   }) {
     super();
@@ -19,6 +23,9 @@ export class AnalyzeView extends BaseView {
     this.metaSampleRateEl = metaSampleRateEl;
     this.metaChannelsEl = metaChannelsEl;
     this.waveformEl = waveformEl;
+    this.settingFftSizeEl = settingFftSizeEl;
+    this.settingMaskingStrengthEl = settingMaskingStrengthEl;
+    this.settingProcessingModeEl = settingProcessingModeEl;
     this.processBtn = processBtn;
 
     this._player = null;
@@ -141,6 +148,14 @@ export class AnalyzeView extends BaseView {
   setProcessEnabled(enabled) {
     if (!this.processBtn) return;
     this.processBtn.disabled = !enabled;
+  }
+
+  getProcessingOptions() {
+    return readProcessingSettings({
+      fftSizeValue: this.settingFftSizeEl?.value,
+      maskingStrengthValue: this.settingMaskingStrengthEl?.value,
+      processingModeValue: this.settingProcessingModeEl?.value,
+    });
   }
 
   onChangeFile(cb) {


### PR DESCRIPTION
This pull request introduces user-configurable processing settings to the audio processing workflow and improves UI behavior by conditionally displaying the application header. The main changes include adding a settings section in the UI, wiring up form controls to collect and validate user input, passing these options through the renderer and main process, and toggling the header's visibility based on the current view.

**Processing Settings Feature:**

* Added a new "Settings" section in the `analyze` view UI, allowing users to specify FFT size, masking strength, and processing mode (`index.html`).
* Introduced the `readProcessingSettings` utility and default values in `ProcessingSettings.js` to read, validate, and sanitize user input for processing options.
* Updated `AnalyzeView` to expose a `getProcessingOptions()` method that reads values from the new settings fields and returns validated options.
* Modified the processing flow so that user-provided options are passed from the UI through the renderer (`AppController`, `DissonanceApi`) and sent to the main process (`preload.js`). 

**UI & Controller Enhancements:**

* The application header is now conditionally shown or hidden depending on the current view, improving focus during analysis and comparison steps (`AppController.js`, `index.html`).

These changes collectively improve the flexibility and usability of the audio processing workflow, giving users more control and a cleaner interface.