### PR TITLE
Multi-platform release workflow (macOS / Windows / Linux)

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,0 +1,107 @@
+name: Release App
+
+# Builds the Dissonance desktop app on each platform's native runner
+# (electron-builder can't cross-build installers) and publishes them to a
+# single GitHub release. Triggered by pushing a v* tag; workflow_dispatch
+# builds the installers as artifacts without publishing, for testing.
+#
+# The platform-native core addon (.node) is expected to already be committed
+# under Build/Release/ (kept current by sync-core-addon.yml). The macOS build
+# is Apple Silicon (arm64) only — matches the single darwin-arm64 addon the
+# core repo ships.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: macos-latest
+            artifact_glob: |
+              dist/*.dmg
+              dist/*.zip
+          - os: windows
+            # Pinned to windows-2022 for the same reason the core repo pins it:
+            # windows-latest (2025) ships a VS version older toolchains trip on.
+            runner: windows-2022
+            artifact_glob: |
+              dist/*.exe
+          - os: linux
+            runner: ubuntu-latest
+            artifact_glob: |
+              dist/*.AppImage
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Build distributables
+        run: npm run dist
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: ${{ matrix.artifact_glob }}
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Dissonance ${{ github.ref_name }}
+          files: artifacts/**/*
+          body: |
+            Multi-platform Dissonance desktop app.
+
+            ## Assets
+            - `*.dmg` / `*.zip` — macOS (Apple Silicon)
+            - `*.exe` — Windows (x64) installer
+            - `*.AppImage` — Linux (x64)
+
+            Bundles the core audio addon with the current psychoacoustic
+            masking model.
+
+            ## Notes
+            - Builds are unsigned/unnotarized — macOS Gatekeeper and Windows
+              SmartScreen will warn on first launch (macOS: right-click → Open;
+              Windows: More info → Run anyway).
+            - macOS is Apple Silicon only; no Intel build.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Dissonance",
   "productName": "Dissonance",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Silencing AI, Preserving Sound",
   "main": "main.js",
@@ -20,6 +20,8 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check .",
     "build": "electron-builder --dir",
+    "predist": "npm run build:css",
+    "dist": "electron-builder --publish never",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -32,13 +34,24 @@
       "buildResources": "resources"
     },
     "mac": {
-      "icon": "resources/icon.png"
+      "icon": "resources/icon.png",
+      "target": [
+        "dmg",
+        "zip"
+      ]
     },
     "win": {
-      "icon": "resources/icon.png"
+      "icon": "resources/icon.png",
+      "target": [
+        "nsis"
+      ]
     },
     "linux": {
-      "icon": "resources/icon.png"
+      "icon": "resources/icon.png",
+      "target": [
+        "AppImage"
+      ],
+      "category": "AudioVideo"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
Adds a `Release App` GitHub Actions workflow that builds the Dissonance desktop app on each platform's native runner and publishes installers to a single GitHub release on `v*` tags. electron-builder can't cross-build installers, so this matrix (macOS-arm64 / Windows-x64 / Linux-x64) is the only reliable way to ship all three.

- **Installer targets** added to the `build` config: `dmg`+`zip` (macOS, Apple Silicon), `nsis` (Windows x64), `AppImage` (Linux x64).
- New `dist` script (`electron-builder --publish never`, with `predist` building CSS).
- Windows runner pinned to `windows-2022` (same VS-toolchain reason as the core repo).
- `workflow_dispatch` builds installers as artifacts without publishing, for testing before a real tag.
- Version bumped to `0.1.1`.

Each platform's installer bundles all three committed `.node` addons; the loader selects the right one at runtime. Binaries were just synced from core `v0.0.5`, so the Windows build now carries the current masking model (the previously shipped v0.1.0 Windows path had none — it was macOS-only).

## Test plan
- [x] `npm run dist` on macOS produces `Dissonance-0.1.1-arm64.dmg` + `-mac.zip`, with all three addons packaged
- [x] `npm run lint`, `npm run format:check`, `npm test` (44) pass
- [ ] After merge: `workflow_dispatch` run to confirm Windows + Linux legs produce `.exe` / `.AppImage` before tagging `v0.1.1`

## Notes
- Builds are unsigned/unnotarized — Gatekeeper/SmartScreen warn on first launch. Signing is future work (needs Apple Developer ID + Windows cert as CI secrets).
- macOS is Apple Silicon only (core ships a single `darwin-arm64` addon).